### PR TITLE
Adds methods for executing dymamodb requests with context

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,29 +2,29 @@ load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library", "go_test")
 
 go_prefix("github.com/vsco/domino")
 
-
 go_library(
-  	name = "domino",
-  	srcs=["domino.go", "expression.go"],
+	name = "domino",
+	srcs=["domino.go", "expression.go"],
 	deps=[
 		"@com_github_aws_aws_sdk_go//aws:go_default_library",
 		"@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",
+		"@com_github_aws_aws_sdk_go//aws/request:go_default_library",
 		"@com_github_aws_aws_sdk_go//service/dynamodb:go_default_library",
 		"@com_github_aws_aws_sdk_go//service/dynamodb/dynamodbattribute:go_default_library",
 	]
 )
- 
+
 go_test(
- 	name  ="domino_test",
- 	srcs = ["domino_test.go"],
+	name  ="domino_test",
+	srcs = ["domino_test.go"],
 	library = ":domino",
 	data = ["//:localstack"],
- 	deps = [
+	deps = [
 		"@com_github_aws_aws_sdk_go//aws:go_default_library",
-        "@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",
+		"@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",
 		"@com_github_aws_aws_sdk_go//service/dynamodb:go_default_library",
 		"@com_github_aws_aws_sdk_go//service/dynamodb/dynamodbattribute:go_default_library",
-		"@com_github_stretchr_testify//assert:go_default_library",		
+		"@com_github_stretchr_testify//assert:go_default_library",
 		"@com_github_aws_aws_sdk_go//aws/credentials:go_default_library",
 		"@com_github_aws_aws_sdk_go//aws/session:go_default_library",
 		]
@@ -33,10 +33,10 @@ go_test(
 
 #### Atlassian / Localstack ####
 genrule(
-    name = "localstack",
-    outs = ["localstack-run-id"],
-    cmd = "docker rm -f localstack || true; docker run -d -p 4567-4576:4567-4576 --name localstack atlassianlabs/localstack > $@",
-    local = 1,
-    message = "Spinning up localstack container...",
-    visibility = ["//visibility:public"],
+	name = "localstack",
+	outs = ["localstack-run-id"],
+	cmd = "docker rm -f localstack || true; docker run -d -p 4567-4576:4567-4576 --name localstack atlassianlabs/localstack > $@",
+	local = 1,
+	message = "Spinning up localstack container...",
+	visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Adds the ability to execute DynamoDB requests with an instance of `context.Context`. 

This is a breaking change since it alters a publicly exposed API method. IMO this isn't a big deal because it's 2017 and people should be passing context everywhere (right??) - else you can always supply `context.Background` at the call-site.

With this change also comes the ability to add [request options](https://godoc.org/github.com/aws/aws-sdk-go/aws/request#Option) to each call. This is a non-breaking change and mirrors the behavior in the `aws/dynamodb` package 