### PR TITLE
adds REMOVE support to UpdateExpressions

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -35,7 +35,7 @@ go_test(
 genrule(
 	name = "localstack",
 	outs = ["localstack-run-id"],
-	cmd = "docker rm -f localstack || true; docker run -d -p 4567-4576:4567-4576 --name localstack atlassianlabs/localstack > $@",
+	cmd = "docker rm -f localstack || true; docker run -d -p 4567-4576:4567-4576 --name localstack atlassianlabs/localstack:0.4.2 > $@",
 	local = 1,
 	message = "Spinning up localstack container...",
 	visibility = ["//visibility:public"],

--- a/expression.go
+++ b/expression.go
@@ -273,6 +273,16 @@ func (Field *DynamoField) SetField(a interface{}, onlyIfEmpty bool) *UpdateExpre
 	return &UpdateExpression{op: "SET", f: f}
 }
 
+/*RemoveField removes a dynamo Field.*/
+func (Field *DynamoField) RemoveField() *UpdateExpression {
+	f := func(c uint) (string, map[string]interface{}, uint) {
+		m := map[string]interface{}{}
+		c++
+		return Field.name, m, c
+	}
+	return &UpdateExpression{op: "REMOVE", f: f}
+}
+
 /*Add adds an amount to dynamo numeric Field*/
 func (Field *Numeric) Add(amount float64) *UpdateExpression {
 	f := func(c uint) (string, map[string]interface{}, uint) {


### PR DESCRIPTION
Adds a new method to the `DyanmoField` struct for generating `REMOVE` update expressions. 

DynamoDB Docs: 
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.REMOVE


