### PR TITLE
do not set empty expression attribute values

### DIFF
--- a/domino.go
+++ b/domino.go
@@ -549,7 +549,10 @@ func (d *putInput) ReturnNone() {
 func (d *putInput) SetConditionExpression(c Expression) *putInput {
 	s, m, _ := c.construct(1, true)
 	d.ConditionExpression = &s
-	d.ExpressionAttributeValues, _ = dynamodbattribute.MarshalMap(m)
+	eav, _ := dynamodbattribute.MarshalMap(m)
+	if len(eav) > 0 {
+		d.ExpressionAttributeValues = eav
+	}
 
 	return d
 }
@@ -754,7 +757,10 @@ func (d *deleteItemInput) ReturnNone() {
 func (d *deleteItemInput) SetConditionExpression(c Expression) *deleteItemInput {
 	s, m, _ := c.construct(1, true)
 	d.ConditionExpression = &s
-	d.ExpressionAttributeValues, _ = dynamodbattribute.MarshalMap(m)
+	eav, _ := dynamodbattribute.MarshalMap(m)
+	if len(eav) > 0 {
+		d.ExpressionAttributeValues = eav
+	}
 	return d
 }
 

--- a/domino_test.go
+++ b/domino_test.go
@@ -319,7 +319,6 @@ func TestPutItem(t *testing.T) {
 
 	err := table.CreateTable().ExecuteWith(ctx, db)
 	defer table.DeleteTable().ExecuteWith(ctx, db)
-
 	assert.NoError(t, err)
 
 	item := User{Email: "joe@email.com", Password: "password"}
@@ -331,6 +330,7 @@ func TestPutItem(t *testing.T) {
 	)
 
 	err = q.ExecuteWith(ctx, db).Result(nil)
+	assert.NoError(t, err)
 
 	v := table.
 		UpdateItem(


### PR DESCRIPTION
Fixes a bug in the `putItem` and `deleteItem` expression generators which could potentially set empty `ExpressionAttributeValues` maps. 

`.ExpressionAttributeValues` needs to be either `nil` or a map with at least one value, otherwise DynamoDB throws this exception:
```
ValidationException, ExpressionAttributeValues must not be empty
```