### PR TITLE
Improve set operations

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,7 @@ new_go_repository(
 new_go_repository(
         name = "com_github_stretchr_testify",
         importpath="github.com/stretchr/testify",
-        commit="976c720a22c8eb4eb6a0b4348ad85ad12491a506"
+        commit="f6abca593680b2315d2075e0f5e2a9751e3f431a"
 )
 new_go_repository(
         name = "com_github_go_ini_ini",
@@ -30,7 +30,7 @@ new_go_repository(
 new_go_repository(
         name = "com_github_davecgh_go_spew",
         importpath="github.com/davecgh/go-spew",
-        commit="6d212800a42e8ab5c146b8ace3490ee17e5225f9"
+        commit="782f4967f2dc4564575ca782fe2d04090b5faca8"
 )
 new_go_repository(
         name = "com_github_jmespath_go_jmespath",

--- a/domino.go
+++ b/domino.go
@@ -834,7 +834,13 @@ func (d *deleteItemInput) SetConditionExpression(c Expression) *deleteItemInput 
 
 	d.ExpressionAttributeNames = n
 
-	d.ExpressionAttributeValues = marshal(m)
+	if d.ExpressionAttributeValues == nil {
+		d.ExpressionAttributeValues = marshal(m)
+	} else {
+		for k, v := range marshal(m) {
+			d.ExpressionAttributeValues[k] = v
+		}
+	}
 
 	return d
 }
@@ -926,7 +932,13 @@ func (d *UpdateInput) SetConditionExpression(c Expression) *UpdateInput {
 
 		d.input.ExpressionAttributeNames = n
 
-		d.input.ExpressionAttributeValues = marshal(m)
+		if d.input.ExpressionAttributeValues == nil {
+			d.input.ExpressionAttributeValues = marshal(m)
+		} else {
+			for k, v := range marshal(m) {
+				d.input.ExpressionAttributeValues[k] = v
+			}
+		}
 
 		return nil
 	}
@@ -967,7 +979,13 @@ func (d *UpdateInput) SetUpdateExpression(exprs ...*UpdateExpression) *UpdateInp
 
 	d.input.UpdateExpression = &s
 
-	d.input.ExpressionAttributeValues = marshal(m)
+	if d.input.ExpressionAttributeValues == nil {
+		d.input.ExpressionAttributeValues = marshal(m)
+	} else {
+		for k, v := range marshal(m) {
+			d.input.ExpressionAttributeValues[k] = v
+		}
+	}
 
 	return d
 }
@@ -1301,7 +1319,13 @@ func (d *ScanInput) SetFilterExpression(c Expression) *ScanInput {
 	d.FilterExpression = &s
 
 	d.ExpressionAttributeNames = n
-	d.ExpressionAttributeValues = marshal(m)
+	if d.ExpressionAttributeValues == nil {
+		d.ExpressionAttributeValues = marshal(m)
+	} else {
+		for k, v := range marshal(m) {
+			d.ExpressionAttributeValues[k] = v
+		}
+	}
 
 	return d
 }

--- a/domino.go
+++ b/domino.go
@@ -129,10 +129,10 @@ type dynamoCollectionField struct {
 }
 
 type dynamoListField struct {
-	DynamoField
+	dynamoCollectionField
 }
 type dynamoSetField struct {
-	DynamoField
+	dynamoCollectionField
 }
 
 type dynamoMapField struct {
@@ -225,9 +225,11 @@ func NumericField(name string) Numeric {
 func NumericSetField(name string) NumericSet {
 	return NumericSet{
 		dynamoSetField{
-			DynamoField{
-				name:  name,
-				_type: dNS,
+			dynamoCollectionField{
+				DynamoField{
+					name:  name,
+					_type: dNS,
+				},
 			},
 		},
 	}
@@ -273,9 +275,11 @@ func BinaryField(name string) Binary {
 func BinarySetField(name string) BinarySet {
 	return BinarySet{
 		dynamoSetField{
-			DynamoField{
-				name:  name,
-				_type: dBS,
+			dynamoCollectionField{
+				DynamoField{
+					name:  name,
+					_type: dBS,
+				},
 			},
 		},
 	}
@@ -285,9 +289,11 @@ func BinarySetField(name string) BinarySet {
 func StringSetField(name string) StringSet {
 	return StringSet{
 		dynamoSetField{
-			DynamoField{
-				name:  name,
-				_type: dSS,
+			dynamoCollectionField{
+				DynamoField{
+					name:  name,
+					_type: dSS,
+				},
 			},
 		},
 	}
@@ -297,9 +303,11 @@ func StringSetField(name string) StringSet {
 func ListField(name string) List {
 	return List{
 		dynamoListField{
-			DynamoField{
-				name:  name,
-				_type: dL,
+			dynamoCollectionField{
+				DynamoField{
+					name:  name,
+					_type: dL,
+				},
 			},
 		},
 	}

--- a/domino.go
+++ b/domino.go
@@ -72,8 +72,10 @@ func marshal(m map[string]interface{}) (o map[string]*dynamodb.AttributeValue) {
 		case *dynamodb.AttributeValue:
 			o[k] = t
 		default:
-			a, _ := dynamodbattribute.Marshal(t)
-			o[k] = a
+			var err error
+			if o[k], err = dynamodbattribute.Marshal(t); err != nil {
+				panic(err)
+			}
 		}
 	}
 

--- a/domino_test.go
+++ b/domino_test.go
@@ -269,10 +269,11 @@ func TestUpdateItem(t *testing.T) {
 			table.loginCount.Increment(1),
 			table.lastLoginDate.SetField(time.Now().UnixNano(), false),
 			table.registrationDate.SetField(time.Now().UnixNano(), true),
-			table.visits.Append(time.Now().UnixNano()),
-			table.preferences.RemoveKey("update_email"),
+			// table.visits.AddInteger(time.Now().UnixNano()),
+			table.preferences.Remove("update_email"),
 		)
 
+	fmt.Println(u.Build())
 	err = u.ExecuteWith(ctx, db).Result(nil)
 	assert.Nil(t, err)
 	g := table.GetItem(KeyValue{"name@email.com", "password"})

--- a/expression.go
+++ b/expression.go
@@ -350,7 +350,7 @@ func (Field *dynamoMapField) Set(key string, a interface{}) *UpdateExpression {
 		ph := generatePlaceholder(key, c)
 		s := fmt.Sprintf("%v.%v = %v", Field.name, key, ph)
 		m := map[string]interface{}{
-			ph: []interface{}{a},
+			ph: a,
 		}
 		c++
 		return s, nil, m, c
@@ -361,14 +361,14 @@ func (Field *dynamoMapField) Set(key string, a interface{}) *UpdateExpression {
 /*RemoveKey removes an element from a map Field*/
 func (Field *dynamoMapField) Remove(key string) *UpdateExpression {
 	f := func(c uint) (string, map[string]*string, map[string]interface{}, uint) {
-		fn := generateNamePlaceholder(Field.name, c)
+		// fn := generateNamePlaceholder(Field.name, c)
+		// c++
+		// fv := generateNamePlaceholder(key, c)
+		s := fmt.Sprintf("%v.%v", Field.name, key)
 		c++
-		fv := generateNamePlaceholder(key, c)
-		s := fmt.Sprintf("%v.%v", fn, fv)
-		c++
-		n := map[string]*string{fn: &Field.name, fv: &key}
+		// n := map[string]*string{fn: &Field.name, fv: &key}
 
-		return s, n, nil, c
+		return s, nil, nil, c
 	}
 	return &UpdateExpression{op: "REMOVE", f: f}
 }
@@ -407,7 +407,7 @@ func (Field *dynamoSetField) AddString(a string) *UpdateExpression {
 	return Field.Add(attr)
 }
 
-func (Field *dynamoSetField) Delete(a interface{}) *UpdateExpression {
+func (Field *dynamoSetField) Delete(a *dynamodb.AttributeValue) *UpdateExpression {
 	f := func(c uint) (string, map[string]*string, map[string]interface{}, uint) {
 		ph := generatePlaceholder(a, c)
 		s := fmt.Sprintf(Field.name+" %v", ph)
@@ -416,6 +416,28 @@ func (Field *dynamoSetField) Delete(a interface{}) *UpdateExpression {
 		return s, nil, m, c
 	}
 	return &UpdateExpression{op: "DELETE", f: f}
+}
+
+func (Field *dynamoSetField) DeleteFloat(a float64) *UpdateExpression {
+	v := strconv.FormatFloat(a, 'E', -1, 64)
+	attr := &dynamodb.AttributeValue{
+		NS: []*string{&v},
+	}
+	return Field.Delete(attr)
+}
+func (Field *dynamoSetField) DeleteInteger(a int64) *UpdateExpression {
+	v := strconv.FormatInt(a, 10)
+	attr := &dynamodb.AttributeValue{
+		NS: []*string{&v},
+	}
+	return Field.Delete(attr)
+}
+
+func (Field *dynamoSetField) DeleteString(a string) *UpdateExpression {
+	attr := &dynamodb.AttributeValue{
+		SS: []*string{&a},
+	}
+	return Field.Delete(attr)
 }
 
 /*Increment a numeric counter Field*/

--- a/expression.go
+++ b/expression.go
@@ -192,7 +192,17 @@ func (p *DynamoField) NotExists() Condition {
 }
 
 /*Contains represents the dynamo contains operator*/
-func (p *DynamoField) Contains(a interface{}) Condition {
+func (p *dynamoCollectionField) Contains(a interface{}) Condition {
+	return Condition{
+		exprF: func(placeholders []string) string {
+			return fmt.Sprintf("contains("+p.name+",%v)", placeholders[0])
+		},
+		args: []interface{}{a},
+	}
+}
+
+/*Contains represents the dynamo contains operator*/
+func (p *String) Contains(a string) Condition {
 	return Condition{
 		exprF: func(placeholders []string) string {
 			return fmt.Sprintf("contains("+p.name+",%v)", placeholders[0])
@@ -202,7 +212,17 @@ func (p *DynamoField) Contains(a interface{}) Condition {
 }
 
 /*Contains represents the dynamo contains size*/
-func (p *DynamoField) Size(op string, a interface{}) Condition {
+func (p *dynamoCollectionField) Size(op string, a interface{}) Condition {
+	return Condition{
+		exprF: func(placeholders []string) string {
+			return fmt.Sprintf("size("+p.name+") "+op+"%v", placeholders[0])
+		},
+		args: []interface{}{a},
+	}
+}
+
+/*Contains represents the dynamo contains size*/
+func (p *String) Size(op string, a interface{}) Condition {
 	return Condition{
 		exprF: func(placeholders []string) string {
 			return fmt.Sprintf("size("+p.name+") "+op+"%v", placeholders[0])
@@ -245,7 +265,7 @@ func (p *DynamoField) GreaterThanOrEq(a interface{}) KeyCondition {
 	return p.operation(gte, a)
 }
 
-func (p *DynamoField) BeginsWith(a interface{}) KeyCondition {
+func (p *String) BeginsWith(a interface{}) KeyCondition {
 	return KeyCondition{
 		Condition{
 			exprF: func(placeholders []string) string {
@@ -361,13 +381,8 @@ func (Field *dynamoMapField) Set(key string, a interface{}) *UpdateExpression {
 /*RemoveKey removes an element from a map Field*/
 func (Field *dynamoMapField) Remove(key string) *UpdateExpression {
 	f := func(c uint) (string, map[string]*string, map[string]interface{}, uint) {
-		// fn := generateNamePlaceholder(Field.name, c)
-		// c++
-		// fv := generateNamePlaceholder(key, c)
 		s := fmt.Sprintf("%v.%v", Field.name, key)
 		c++
-		// n := map[string]*string{fn: &Field.name, fv: &key}
-
 		return s, nil, nil, c
 	}
 	return &UpdateExpression{op: "REMOVE", f: f}

--- a/expression.go
+++ b/expression.go
@@ -426,7 +426,7 @@ func (Field *dynamoSetField) Delete(a *dynamodb.AttributeValue) *UpdateExpressio
 	f := func(c uint) (string, map[string]*string, map[string]interface{}, uint) {
 		ph := generatePlaceholder(a, c)
 		s := fmt.Sprintf(Field.name+" %v", ph)
-		m := map[string]interface{}{ph: []interface{}{a}}
+		m := map[string]interface{}{ph: a}
 		c++
 		return s, nil, m, c
 	}

--- a/expression.go
+++ b/expression.go
@@ -140,7 +140,7 @@ func Not(c Expression) negation {
 /*********************************************************************************/
 /******************************** Conditions *************************************/
 /*********************************************************************************/
-/*Conditions that only apply to keys*/
+/*******Conditions that only apply to keys*********/
 
 func (c Condition) construct(counter uint, topLevel bool) (string, map[string]*string, map[string]interface{}, uint) {
 	a := make([]string, len(c.args))
@@ -162,7 +162,7 @@ func (c Condition) String() string {
 	return s
 }
 
-/*In represents the dynamo 'in' operator*/
+/*In constructs a list inclusion condition filter*/
 func (p *DynamoField) In(elems ...interface{}) Condition {
 	return Condition{
 		exprF: func(placeholders []string) string {
@@ -173,7 +173,7 @@ func (p *DynamoField) In(elems ...interface{}) Condition {
 
 }
 
-/*Exists represents the dynamo attribute_exists operator*/
+/*Exists constructs a existential condition filter*/
 func (p *DynamoField) Exists() Condition {
 	return Condition{
 		exprF: func(placeholders []string) string {
@@ -182,7 +182,7 @@ func (p *DynamoField) Exists() Condition {
 	}
 }
 
-/*NotExists represents the dynamo attribute_not_exists operator*/
+/*NotExists constructs a existential exclusion condition filter*/
 func (p *DynamoField) NotExists() Condition {
 	return Condition{
 		exprF: func(placeholders []string) string {
@@ -191,7 +191,7 @@ func (p *DynamoField) NotExists() Condition {
 	}
 }
 
-/*Contains represents the dynamo contains operator*/
+/*Contains constructs a set inclusion condition filter*/
 func (p *dynamoCollectionField) Contains(a interface{}) Condition {
 	return Condition{
 		exprF: func(placeholders []string) string {
@@ -201,7 +201,7 @@ func (p *dynamoCollectionField) Contains(a interface{}) Condition {
 	}
 }
 
-/*Contains represents the dynamo contains operator*/
+/*Contains constructs a string inclusion condition filter*/
 func (p *String) Contains(a string) Condition {
 	return Condition{
 		exprF: func(placeholders []string) string {
@@ -211,8 +211,11 @@ func (p *String) Contains(a string) Condition {
 	}
 }
 
-/*Contains represents the dynamo contains size*/
-func (p *dynamoCollectionField) Size(op string, a interface{}) Condition {
+/*
+* Size constructs a collection length condition filter
+* table.someListField.Size("<", 25)  
+*/
+func (p *dynamoCollectionField) Size(op string, a int) Condition {
 	return Condition{
 		exprF: func(placeholders []string) string {
 			return fmt.Sprintf("size("+p.name+") "+op+"%s", placeholders[0])
@@ -221,8 +224,11 @@ func (p *dynamoCollectionField) Size(op string, a interface{}) Condition {
 	}
 }
 
-/*Contains represents the dynamo contains size*/
-func (p *String) Size(op string, a interface{}) Condition {
+/*
+* Size constructs a string length condition filter
+* table.someStringField.Size(">=", 5)  
+*/
+func (p *String) Size(op string, a int) Condition {
 	return Condition{
 		exprF: func(placeholders []string) string {
 			return fmt.Sprintf("size("+p.name+") "+op+"%s", placeholders[0])


### PR DESCRIPTION
Improves and adds operations on sets. Previously, there was no support for single ints or floats, since the aws sdk requires special handling for sets: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.ADD

In particular it requires the value that is being added or deleted, be explicitly set to a Set type.