### PR TITLE
Format BUILD, allow target access from external workspaces

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,39 +3,43 @@ load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library", "go_test")
 go_prefix("github.com/vsco/domino")
 
 go_library(
-	name = "domino",
-	srcs=["domino.go", "expression.go"],
-	deps=[
-		"@com_github_aws_aws_sdk_go//aws:go_default_library",
-		"@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",
-		"@com_github_aws_aws_sdk_go//aws/request:go_default_library",
-		"@com_github_aws_aws_sdk_go//service/dynamodb:go_default_library",
-		"@com_github_aws_aws_sdk_go//service/dynamodb/dynamodbattribute:go_default_library",
-	]
+    name = "domino",
+    srcs = [
+        "domino.go",
+        "expression.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_aws_aws_sdk_go//aws:go_default_library",
+        "@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",
+        "@com_github_aws_aws_sdk_go//aws/request:go_default_library",
+        "@com_github_aws_aws_sdk_go//service/dynamodb:go_default_library",
+        "@com_github_aws_aws_sdk_go//service/dynamodb/dynamodbattribute:go_default_library",
+    ],
 )
 
 go_test(
-	name  ="domino_test",
-	srcs = ["domino_test.go"],
-	library = ":domino",
-	data = ["//:dynamodb"],
-	deps = [
-		"@com_github_aws_aws_sdk_go//aws:go_default_library",
-		"@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",
-		"@com_github_aws_aws_sdk_go//service/dynamodb:go_default_library",
-		"@com_github_aws_aws_sdk_go//service/dynamodb/dynamodbattribute:go_default_library",
-		"@com_github_stretchr_testify//assert:go_default_library",
-		"@com_github_aws_aws_sdk_go//aws/credentials:go_default_library",
-		"@com_github_aws_aws_sdk_go//aws/session:go_default_library",
-		]
- )
+    name = "domino_test",
+    srcs = ["domino_test.go"],
+    data = ["//:dynamodb"],
+    library = ":domino",
+    deps = [
+        "@com_github_aws_aws_sdk_go//aws:go_default_library",
+        "@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",
+        "@com_github_aws_aws_sdk_go//aws/credentials:go_default_library",
+        "@com_github_aws_aws_sdk_go//aws/session:go_default_library",
+        "@com_github_aws_aws_sdk_go//service/dynamodb:go_default_library",
+        "@com_github_aws_aws_sdk_go//service/dynamodb/dynamodbattribute:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
+)
 
 #### Atlassian / Localstack ####
 genrule(
-	name = "dynamodb",
-	outs = ["localstack-run-id"],
-	cmd = "docker rm -f localstack || true; docker run -d -p 4567-4576:4567-4576 --name localstack atlassianlabs/localstack:0.4.1 > $@",
-	local = 1,
-	message = "Spinning up localstack container...",
-	visibility = ["//visibility:public"],
+    name = "dynamodb",
+    outs = ["localstack-run-id"],
+    cmd = "docker rm -f localstack || true; docker run -d -p 4567-4576:4567-4576 --name localstack atlassianlabs/localstack:0.4.1 > $@",
+    local = 1,
+    message = "Spinning up localstack container...",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
In order to use this repo with newer versions of `rules_go`, we need to ensure the target is public.
* It seems that in previous versions of `rules_go`, it ignored visibilty, and we could use the `:go_default_library` target for this to work.

Also ran [buildifier](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md) over the `BUILD` file.