### PR TITLE
Shorter Expression Attribute Value Names

### DIFF
--- a/domino.go
+++ b/domino.go
@@ -625,7 +625,7 @@ func (d *putInput) ReturnNone() *putInput {
 	return d
 }
 func (d *putInput) SetConditionExpression(c Expression) *putInput {
-	s, n, m, _ := c.construct(1, true)
+	s, n, m, _ := c.construct("cond", 1, true)
 	d.ConditionExpression = &s
 
 	d.ExpressionAttributeNames = n
@@ -839,7 +839,7 @@ func (d *deleteItemInput) ReturnNone() *deleteItemInput {
 }
 
 func (d *deleteItemInput) SetConditionExpression(c Expression) *deleteItemInput {
-	s, n, m, _ := c.construct(1, true)
+	s, n, m, _ := c.construct("cond", 1, true)
 	d.ConditionExpression = &s
 
 	d.ExpressionAttributeNames = n
@@ -937,7 +937,7 @@ func (d *UpdateInput) ReturnNone() *UpdateInput {
 
 func (d *UpdateInput) SetConditionExpression(c Expression) *UpdateInput {
 	delayed := func() error {
-		s, n, m, _ := c.construct(1, true)
+		s, n, m, _ := c.construct("cond", 1, true)
 		d.input.ConditionExpression = &s
 
 		d.input.ExpressionAttributeNames = n
@@ -1071,7 +1071,7 @@ func (table DynamoTable) Query(partitionKeyCondition KeyCondition, rangeKeyCondi
 		e = partitionKeyCondition
 	}
 
-	s, n, m, _ := e.construct(0, true)
+	s, n, m, _ := e.construct("cond", 0, true)
 	q.TableName = &table.Name
 	q.KeyConditionExpression = &s
 	q.ExpressionAttributeNames = n
@@ -1118,7 +1118,7 @@ func (d *QueryInput) WithConsumedCapacityHandler(f func(*dynamodb.ConsumedCapaci
 }
 
 func (d *QueryInput) SetFilterExpression(c Expression) *QueryInput {
-	s, n, m, _ := c.construct(1, true)
+	s, n, m, _ := c.construct("filter", 1, true)
 	d.FilterExpression = &s
 
 	d.ExpressionAttributeNames = n
@@ -1339,7 +1339,7 @@ func (d *ScanInput) SetPageSize(pageSize int) *ScanInput {
 }
 
 func (d *ScanInput) SetFilterExpression(c Expression) *ScanInput {
-	s, n, m, _ := c.construct(1, true)
+	s, n, m, _ := c.construct("filter", 1, true)
 	d.FilterExpression = &s
 
 	d.ExpressionAttributeNames = n

--- a/domino_test.go
+++ b/domino_test.go
@@ -421,8 +421,10 @@ func TestExpressions(t *testing.T) {
 		SetScanForward(true).
 		SetFilterExpression(expr)
 
-	expectedFilter := "registrationDate = :123_1 OR contains(lastName,:25_2) OR (NOT registrationDate = :345_3) OR (size(visits) <=:25_4 AND size(firstName) >=:25_5) OR registrationDate = :test_6 OR registrationDate <= :test_7 OR (registrationDate between :0_8 and :1_9) OR (registrationDate in (:0_10,:1_11))"
+	expectedFilter := "registrationDate = :filter_1 OR contains(lastName,:filter_2) OR (NOT registrationDate = :filter_3) OR (size(visits) <=:filter_4 AND size(firstName) >=:filter_5) OR registrationDate = :filter_6 OR registrationDate <= :filter_7 OR (registrationDate between :filter_8 and :filter_9) OR (registrationDate in (:filter_10,:filter_11))"
 	assert.Equal(t, expectedFilter, *q.Build().FilterExpression)
+
+	fmt.Println(*q.Build())
 
 	channel := make(chan *User)
 	errChan := q.ExecuteWith(ctx, db).StreamWithChannel(channel)

--- a/expression.go
+++ b/expression.go
@@ -43,12 +43,12 @@ const (
 var nonalpha *regexp.Regexp = regexp.MustCompile("[^a-zA-Z_0-9]")
 
 func generatePlaceholder(a interface{}, counter uint) string {
-	r := fmt.Sprintf("%v_%d", a, counter)
+	r := fmt.Sprintf("%s_%d", "a", counter)
 	return ":" + nonalpha.ReplaceAllString(r, "_")
 }
 
 func generateNamePlaceholder(a interface{}, counter uint) string {
-	r := fmt.Sprintf("%v_%d", a, counter)
+	r := fmt.Sprintf("%s_%d","a", counter)
 	return "#" + nonalpha.ReplaceAllString(r, "_")
 }
 

--- a/expression.go
+++ b/expression.go
@@ -11,7 +11,7 @@ import (
 
 /*Expression represents a dynamo Condition expression, i.e. And(if_empty(...), size(path) >0) */
 type Expression interface {
-	construct(counter uint, b bool) (string, map[string]*string, map[string]interface{}, uint)
+	construct(prefix string, counter uint, b bool) (string, map[string]*string, map[string]interface{}, uint)
 }
 type ExpressionGroup struct {
 	expressions []Expression
@@ -42,13 +42,13 @@ const (
 
 var nonalpha *regexp.Regexp = regexp.MustCompile("[^a-zA-Z_0-9]")
 
-func generatePlaceholder(a interface{}, counter uint) string {
-	r := fmt.Sprintf("%s_%d", "a", counter)
+func generatePlaceholder(a string, counter uint) string {
+	r := fmt.Sprintf("%s_%d", a, counter)
 	return ":" + nonalpha.ReplaceAllString(r, "_")
 }
 
-func generateNamePlaceholder(a interface{}, counter uint) string {
-	r := fmt.Sprintf("%s_%d","a", counter)
+func generateNamePlaceholder(a string, counter uint) string {
+	r := fmt.Sprintf("%s_%d", a, counter)
 	return "#" + nonalpha.ReplaceAllString(r, "_")
 }
 
@@ -57,14 +57,14 @@ func generateNamePlaceholder(a interface{}, counter uint) string {
 /*********************************************************************************/
 /*Groups expression by AND and OR operators, i.e. <expr> OR <expr>*/
 
-func (e ExpressionGroup) construct(counter uint, topLevel bool) (expr string, exprNames map[string]*string, exprValues map[string]interface{}, c uint) {
+func (e ExpressionGroup) construct(prefix string, counter uint, topLevel bool) (expr string, exprNames map[string]*string, exprValues map[string]interface{}, c uint) {
 	a := e.expressions
 
 	for i := 0; i < len(a); i++ {
 		if i > 0 {
 			expr += " " + e.op + " "
 		}
-		substring, names, placeholders, newCounter := a[i].construct(counter, false)
+		substring, names, placeholders, newCounter := a[i].construct(prefix, counter, false)
 		expr += substring
 		if exprValues == nil && len(placeholders) > 0 {
 			exprValues = placeholders
@@ -109,7 +109,7 @@ func And(c ...Expression) ExpressionGroup {
 
 /*String stringifies expressions for easy debugging*/
 func (c ExpressionGroup) String() string {
-	s, _, _, _ := c.construct(0, true)
+	s, _, _, _ := c.construct("expr", 0, true)
 	return s
 }
 
@@ -117,8 +117,8 @@ func (c ExpressionGroup) String() string {
 /******************************** Negation Expression ****************************/
 /*********************************************************************************/
 
-func (n negation) construct(counter uint, topLevel bool) (string, map[string]*string, map[string]interface{}, uint) {
-	s, names, m, c := n.expression.construct(counter, topLevel)
+func (n negation) construct(prefix string, counter uint, topLevel bool) (string, map[string]*string, map[string]interface{}, uint) {
+	s, names, m, c := n.expression.construct(prefix, counter, topLevel)
 	r := "NOT " + s
 	if !topLevel {
 		r = fmt.Sprintf("(%s)", r)
@@ -128,7 +128,7 @@ func (n negation) construct(counter uint, topLevel bool) (string, map[string]*st
 }
 
 func (c negation) String() string {
-	s, _, _, _ := c.construct(0, true)
+	s, _, _, _ := c.construct("neg", 0, true)
 	return s
 }
 
@@ -142,11 +142,11 @@ func Not(c Expression) negation {
 /*********************************************************************************/
 /*******Conditions that only apply to keys*********/
 
-func (c Condition) construct(counter uint, topLevel bool) (string, map[string]*string, map[string]interface{}, uint) {
+func (c Condition) construct(prefix string, counter uint, topLevel bool) (string, map[string]*string, map[string]interface{}, uint) {
 	a := make([]string, len(c.args))
 	var m map[string]interface{}
 	for i, b := range c.args {
-		a[i] = generatePlaceholder(b, counter)
+		a[i] = generatePlaceholder(prefix, counter)
 		if m == nil {
 			m = map[string]interface{}{}
 		}
@@ -158,7 +158,7 @@ func (c Condition) construct(counter uint, topLevel bool) (string, map[string]*s
 }
 
 func (c Condition) String() string {
-	s, _, _, _ := c.construct(0, true)
+	s, _, _, _ := c.construct("cond", 0, true)
 	return s
 }
 
@@ -213,8 +213,8 @@ func (p *String) Contains(a string) Condition {
 
 /*
 * Size constructs a collection length condition filter
-* table.someListField.Size("<", 25)  
-*/
+* table.someListField.Size("<", 25)
+ */
 func (p *dynamoCollectionField) Size(op string, a int) Condition {
 	return Condition{
 		exprF: func(placeholders []string) string {
@@ -226,8 +226,8 @@ func (p *dynamoCollectionField) Size(op string, a int) Condition {
 
 /*
 * Size constructs a string length condition filter
-* table.someStringField.Size(">=", 5)  
-*/
+* table.someStringField.Size(">=", 5)
+ */
 func (p *String) Size(op string, a int) Condition {
 	return Condition{
 		exprF: func(placeholders []string) string {
@@ -304,7 +304,7 @@ type UpdateExpression struct {
 /*SetField sets a dynamo Field. Set onlyIfEmpty to true if you want to prevent overwrites*/
 func (Field *DynamoField) SetField(a interface{}, onlyIfEmpty bool) *UpdateExpression {
 	f := func(c uint) (string, map[string]*string, map[string]interface{}, uint) {
-		ph := generatePlaceholder(a, c)
+		ph := generatePlaceholder("update", c)
 		r := ph
 		if onlyIfEmpty {
 			r = fmt.Sprintf("if_not_exists(%s,%s)", Field.name, ph)
@@ -331,7 +331,7 @@ func (Field *DynamoField) RemoveField() *UpdateExpression {
 /*Add adds an amount to dynamo numeric Field*/
 func (Field *Numeric) Add(amount float64) *UpdateExpression {
 	f := func(c uint) (string, map[string]*string, map[string]interface{}, uint) {
-		ph := generatePlaceholder(amount, c)
+		ph := generatePlaceholder("update", c)
 		s := Field.name + " " + ph
 		m := map[string]interface{}{ph: amount}
 		c++
@@ -343,7 +343,7 @@ func (Field *Numeric) Add(amount float64) *UpdateExpression {
 /*Append appends an element to a list Field*/
 func (Field *dynamoListField) Append(a interface{}) *UpdateExpression {
 	f := func(c uint) (string, map[string]*string, map[string]interface{}, uint) {
-		ph := generatePlaceholder(a, c)
+		ph := generatePlaceholder("update", c)
 		s := fmt.Sprintf(Field.name+" = list_append(%s,"+Field.name+")", ph)
 		m := map[string]interface{}{ph: []interface{}{a}}
 		c++
@@ -354,7 +354,7 @@ func (Field *dynamoListField) Append(a interface{}) *UpdateExpression {
 
 func (Field *dynamoListField) Set(index int, a interface{}) *UpdateExpression {
 	f := func(c uint) (string, map[string]*string, map[string]interface{}, uint) {
-		ph := generatePlaceholder(a, c)
+		ph := generatePlaceholder("update", c)
 		s := fmt.Sprintf(Field.name+"[%d] = %s", index, ph)
 		m := map[string]interface{}{ph: []interface{}{a}}
 		c++
@@ -396,7 +396,7 @@ func (Field *dynamoMapField) Remove(key string) *UpdateExpression {
 
 func (Field *dynamoSetField) Add(a *dynamodb.AttributeValue) *UpdateExpression {
 	f := func(c uint) (string, map[string]*string, map[string]interface{}, uint) {
-		ph := generatePlaceholder(c, c)
+		ph := generatePlaceholder("update", c)
 		s := fmt.Sprintf(Field.name+" %s", ph)
 		m := map[string]interface{}{ph: a}
 
@@ -430,7 +430,7 @@ func (Field *dynamoSetField) AddString(a string) *UpdateExpression {
 
 func (Field *dynamoSetField) Delete(a *dynamodb.AttributeValue) *UpdateExpression {
 	f := func(c uint) (string, map[string]*string, map[string]interface{}, uint) {
-		ph := generatePlaceholder(a, c)
+		ph := generatePlaceholder("update", c)
 		s := fmt.Sprintf(Field.name+" %s", ph)
 		m := map[string]interface{}{ph: a}
 		c++


### PR DESCRIPTION
Since the counter is already guaranteed to be unique, we don't need to stringify the attribute value. It is sufficient to prepend a operation type to the attribute:
```
{
  ExpressionAttributeValues: {
    :filter_2: {
      S: "25"
    },
    :filter_6: {
      S: "test"
    },
    :filter_9: {
      S: "1"
    },
    :filter_3: {
      N: "345"
    },
    :filter_4: {
      N: "25"
    },
    :filter_10: {
      S: "0"
    },
    :cond_1: {
      S: "password"
    },
    :filter_1: {
      N: "123"
    },
    :filter_5: {
      N: "25"
    },
    :filter_8: {
      S: "0"
    },
    :filter_7: {
      S: "test"
    },
    :filter_11: {
      S: "1"
    },
    :cond_0: {
      S: "name@email.com"
    }
  },
  FilterExpression: "registrationDate = :filter_1 OR contains(lastName,:filter_2) OR (NOT registrationDate = :filter_3) OR (size(visits) <=:filter_4 AND size(firstName) >=:filter_5) OR registrationDate = :filter_6 OR registrationDate <= :filter_7 OR (registrationDate between :filter_8 and :filter_9) OR (registrationDate in (:filter_10,:filter_11))",
  KeyConditionExpression: "email = :cond_0 AND password = :cond_1",
  Limit: 100,
  ScanIndexForward: true,
  TableName: "users"
}
```