### PR TITLE
Upgrade Build to Bazel 0.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,10 @@ services:
 
 env:
   global:
-    - BAZEL_VERSION=0.5.4
+    - BAZEL_VERSION=0.8.1
 
 before_install:
-  - mkdir -p ${HOME}/bazel/install
-  - pushd ${HOME}/bazel/install
-  - wget --no-clobber https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb
-  # - sha256sum -c tools/bazel_${BAZEL_VERSION}-linux-x86_64.deb.sha256
-  - sudo dpkg -i bazel_${BAZEL_VERSION}-linux-x86_64.deb
-  - popd
+  - script/install-bazel
 
 install:
   - bazel info

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,6 @@ install:
 script:
   - bazel test --test_output=errors  //...
 
-cache:
-  timeout: 300
-  directories:
-    - $HOME/.vsco/bazel
-
 notifications:
   email: false
   slack: false

--- a/BUILD
+++ b/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library", "go_test")
 go_prefix("github.com/vsco/domino")
 
 go_library(
-    name = "domino",
+    name = "go_default_library",
     srcs = [
         "domino.go",
         "expression.go",
@@ -19,10 +19,10 @@ go_library(
 )
 
 go_test(
-    name = "domino_test",
+    name = "go_default_test",
     srcs = ["domino_test.go"],
     data = ["//:dynamodb"],
-    library = ":domino",
+    library = ":go_default_library",
     deps = [
         "@com_github_aws_aws_sdk_go//aws:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",
@@ -38,7 +38,7 @@ go_test(
 genrule(
     name = "dynamodb",
     outs = ["localstack-run-id"],
-    cmd = "docker rm -f localstack || true; docker run -d -p 4567-4576:4567-4576 --name localstack atlassianlabs/localstack:0.4.1 > $@",
+    cmd = "docker stop localstack || true; docker rm -f localstack || true; docker run -d -p 4567-4576:4567-4576 --name localstack atlassianlabs/localstack:0.4.1 > $@",
     local = 1,
     message = "Spinning up localstack container...",
     visibility = ["//visibility:public"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,39 +1,47 @@
-git_repository(
+http_archive(
     name = "io_bazel_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.4.4",
+    sha256 = "90bb270d0a92ed5c83558b2797346917c46547f6f7103e648941ecdb6b9d0e72",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.8.1/rules_go-0.8.1.tar.gz",
 )
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "new_go_repository")
 
-go_repositories()
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains", "go_repository")
 
-new_go_repository(
-        name = "com_github_aws_aws_sdk_go",
-        importpath="github.com/aws/aws-sdk-go",
-        commit="v1.8.16"
+go_rules_dependencies()
+
+go_register_toolchains()
+
+go_repository(
+    name = "com_github_aws_aws_sdk_go",
+    commit = "v1.8.16",
+    importpath = "github.com/aws/aws-sdk-go",
 )
-new_go_repository(
-        name = "com_github_stretchr_testify",
-        importpath="github.com/stretchr/testify",
-        commit="f6abca593680b2315d2075e0f5e2a9751e3f431a"
+
+go_repository(
+    name = "com_github_stretchr_testify",
+    commit = "f6abca593680b2315d2075e0f5e2a9751e3f431a",
+    importpath = "github.com/stretchr/testify",
 )
-new_go_repository(
-        name = "com_github_go_ini_ini",
-        importpath="github.com/go-ini/ini",
-        commit="6e4869b434bd001f6983749881c7ead3545887d8"
+
+go_repository(
+    name = "com_github_go_ini_ini",
+    commit = "6e4869b434bd001f6983749881c7ead3545887d8",
+    importpath = "github.com/go-ini/ini",
 )
-new_go_repository(
-        name = "com_github_pmezard_go_difflib",
-        importpath="github.com/pmezard/go-difflib",
-        commit="792786c7400a136282c1664665ae0a8db921c6c2"
+
+go_repository(
+    name = "com_github_pmezard_go_difflib",
+    commit = "792786c7400a136282c1664665ae0a8db921c6c2",
+    importpath = "github.com/pmezard/go-difflib",
 )
-new_go_repository(
-        name = "com_github_davecgh_go_spew",
-        importpath="github.com/davecgh/go-spew",
-        commit="782f4967f2dc4564575ca782fe2d04090b5faca8"
+
+go_repository(
+    name = "com_github_davecgh_go_spew",
+    commit = "782f4967f2dc4564575ca782fe2d04090b5faca8",
+    importpath = "github.com/davecgh/go-spew",
 )
-new_go_repository(
-        name = "com_github_jmespath_go_jmespath",
-        importpath="github.com/jmespath/go-jmespath",
-        commit="bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d"
+
+go_repository(
+    name = "com_github_jmespath_go_jmespath",
+    commit = "bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d",
+    importpath = "github.com/jmespath/go-jmespath",
 )

--- a/script/install-bazel
+++ b/script/install-bazel
@@ -5,7 +5,7 @@ set -e
 test "Darwin" = "$(uname)" && exit 1
 
 if [ -z "$BAZEL_VERSION" ]; then
-   BAZEL_VERSION="0.5.4"
+   BAZEL_VERSION="0.8.1"
 fi
 
 if [ -z "$BAZEL_INSTALL" ]; then

--- a/script/install-bazel
+++ b/script/install-bazel
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+# linux install only
+test "Darwin" = "$(uname)" && exit 1
+
+if [ -z "$BAZEL_VERSION" ]; then
+   BAZEL_VERSION="0.5.4"
+fi
+
+if [ -z "$BAZEL_INSTALL" ]; then
+   BAZEL_INSTALL="${HOME}/bazel/install"
+fi
+
+# if BAZEL_OUTPUT_BASE is set, create the directory and point all execution to that directory
+if [ -n "$BAZEL_OUTPUT_BASE" ]; then
+   mkdir -p $BAZEL_OUTPUT_BASE
+   echo "startup --output_base=${BAZEL_OUTPUT_BASE}" >> ~/.bazelrc
+fi
+
+# install bazel and return to previous directory
+mkdir -p $BAZEL_INSTALL
+pushd $BAZEL_INSTALL
+wget --no-clobber "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb"
+sudo dpkg -i "bazel_${BAZEL_VERSION}-linux-x86_64.deb"
+popd
+


### PR DESCRIPTION
Upgrade to Bazel `0.8.1` and [bazelbuild/rules_go@0.8.1](https://github.com/bazelbuild/rules_go/releases/tag/0.8.1)

* Add Bazel install script
* Rename back to `go_default_library` for external inclusion simplicity
* Run `buildifier` on everything