### PR TITLE
Updates Go rules to 0.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ services:
   - docker
 
 env:
-  global:
-    - BAZEL_VERSION=0.8.1
+  - BAZEL_VERSION=0.8.1
+  - BAZEL_VERSION=0.13.1
+  - BAZEL_VERSION=0.14.0
 
 before_install:
   - script/install-bazel

--- a/BUILD
+++ b/BUILD
@@ -1,9 +1,8 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_library", "go_test")
-
-go_prefix("github.com/vsco/domino")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
+    importpath = "github.com/vsco/domino",
     srcs = [
         "domino.go",
         "expression.go",
@@ -22,7 +21,7 @@ go_test(
     name = "go_default_test",
     srcs = ["domino_test.go"],
     data = ["//:dynamodb"],
-    library = ":go_default_library",
+    embed = [":go_default_library"],
     deps = [
         "@com_github_aws_aws_sdk_go//aws:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,40 +1,54 @@
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.9.0",
+    tag = "0.12.0"
 )
+git_repository(
+    name = "bazel_gazelle",
+    remote = "https://github.com/bazelbuild/bazel-gazelle.git",
+    tag = "0.12.0",
+)
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_rules_dependencies",
+    "go_register_toolchains",
+)
+go_rules_dependencies()
+go_register_toolchains()
+load(
+    "@bazel_gazelle//:deps.bzl",
+    "gazelle_dependencies",
+    "go_repository",
+)
+gazelle_dependencies()
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "go_repository")
-
-go_repositories()
-
 go_repository(
-        name = "com_github_aws_aws_sdk_go",
-        importpath="github.com/aws/aws-sdk-go",
-        commit="v1.8.16"
+    name = "com_github_aws_aws_sdk_go",
+    importpath="github.com/aws/aws-sdk-go",
+    commit="v1.8.16"
 )
 go_repository(
-        name = "com_github_stretchr_testify",
-        importpath="github.com/stretchr/testify",
-        commit="f6abca593680b2315d2075e0f5e2a9751e3f431a"
+    name = "com_github_stretchr_testify",
+    importpath="github.com/stretchr/testify",
+    commit="f6abca593680b2315d2075e0f5e2a9751e3f431a"
 )
 go_repository(
-        name = "com_github_go_ini_ini",
-        importpath="github.com/go-ini/ini",
-        commit="6e4869b434bd001f6983749881c7ead3545887d8"
+    name = "com_github_go_ini_ini",
+    importpath="github.com/go-ini/ini",
+    commit="6e4869b434bd001f6983749881c7ead3545887d8"
 )
 go_repository(
-        name = "com_github_pmezard_go_difflib",
-        importpath="github.com/pmezard/go-difflib",
-        commit="792786c7400a136282c1664665ae0a8db921c6c2"
+    name = "com_github_pmezard_go_difflib",
+    importpath="github.com/pmezard/go-difflib",
+    commit="792786c7400a136282c1664665ae0a8db921c6c2"
 )
 go_repository(
-        name = "com_github_davecgh_go_spew",
-        importpath="github.com/davecgh/go-spew",
-        commit="782f4967f2dc4564575ca782fe2d04090b5faca8"
+    name = "com_github_davecgh_go_spew",
+    importpath="github.com/davecgh/go-spew",
+    commit="782f4967f2dc4564575ca782fe2d04090b5faca8"
 )
 go_repository(
-        name = "com_github_jmespath_go_jmespath",
-        importpath="github.com/jmespath/go-jmespath",
-        commit="bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d"
+    name = "com_github_jmespath_go_jmespath",
+    importpath="github.com/jmespath/go-jmespath",
+    commit="bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d"
 )


### PR DESCRIPTION
This change updates the Go rules to 0.12.0 from 0.9.0. I have checked that the changes in the `BUILD` file are still compatible with v0.9.0 Go rules, but this file can now be used by workspaces using 0.12.0 Go rules.